### PR TITLE
Points have associated datetime

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -57,6 +57,7 @@ class Participant(models.Model):
         return self.learner.first_name
 
     def award_scenario(self, event, module):
+
         if module is not None:
             query = Q(event=event, course=self.classs.course, module=module) \
                 | Q(event=event, course=self.classs.course, module=None)
@@ -69,7 +70,7 @@ class Participant(models.Model):
             if scenario.point is not None:
                 p = ParticipantPointBonusRel(
                     participant=self, pointbonus=scenario.point,
-                    scenario=scenario)
+                    scenario=scenario, awarddate=datetime.now())
                 p.save()
 
             # Badges may only be awarded once
@@ -98,7 +99,8 @@ class ParticipantPointBonusRel(models.Model):
     participant = models.ForeignKey(Participant)
     pointbonus = models.ForeignKey(GamificationPointBonus)
     scenario = models.ForeignKey(GamificationScenario)
-    awarddate = models.DateTimeField("Award Date", null=True, blank=True)
+    awarddate = models.DateTimeField("Award Date", null=True, blank=True,
+                                     default=datetime.now())
 
 
 class ParticipantBadgeTemplateRel(models.Model):

--- a/core/tests.py
+++ b/core/tests.py
@@ -2,8 +2,10 @@ from django.test import TestCase
 from datetime import datetime
 from auth.models import Learner
 from organisation.models import Course, Module, School, Organisation
-from core.models import Participant, Class, ParticipantBadgeTemplateRel
-from gamification.models import GamificationBadgeTemplate, GamificationPointBonus, GamificationScenario
+from core.models import Participant, Class, ParticipantBadgeTemplateRel, \
+    ParticipantPointBonusRel
+from gamification.models import GamificationBadgeTemplate, \
+    GamificationPointBonus, GamificationScenario
 
 
 class TestMessage(TestCase):
@@ -99,7 +101,11 @@ class TestMessage(TestCase):
         b = ParticipantBadgeTemplateRel.objects.get(participant=participant)
         self.assertTrue(b.awarddate)
 
-    def test_award_scenario_none_module(self):
+         # check that ParticipantPointTemplateRel has a datetime
+        b = ParticipantPointBonusRel.objects.get(participant=participant)
+        self.assertTrue(b.awarddate)
+
+    def test_award_scenario_datetime(self):
         participant = self.create_participant(
             self.learner,
             self.classs,
@@ -119,3 +125,8 @@ class TestMessage(TestCase):
         # check badge was awarded
         b = ParticipantBadgeTemplateRel.objects.get(participant=participant)
         self.assertTrue(b.awarddate)
+
+        # check that ParticipantPointTemplateRel has a datetime
+        b = ParticipantPointBonusRel.objects.get(participant=participant)
+        self.assertTrue(b.awarddate)
+


### PR DESCRIPTION
Datetime should be saved when point scenario awarded
