### PR TITLE
Feature/issue 42 refactor award scenario

### DIFF
--- a/content/migrations/0004_test_question_default.py
+++ b/content/migrations/0004_test_question_default.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        questions = orm.TestingQuestion.objects.all()
+        for question in questions:
+            question.points = 1
+            question.save()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'content.learningchapter': {
+            'Meta': {'object_name': 'LearningChapter'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Module']", 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'content.testingbank': {
+            'Meta': {'object_name': 'TestingBank'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Module']", 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'question_order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'content.testingquestion': {
+            'Meta': {'object_name': 'TestingQuestion'},
+            'answer_content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bank': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingBank']", 'null': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'difficulty': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'points': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'question_content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'textbook_link': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'})
+        },
+        u'content.testingquestionoption': {
+            'Meta': {'object_name': 'TestingQuestionOption'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'correct': ('django.db.models.fields.BooleanField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'question': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingQuestion']", 'null': 'True'})
+        },
+        u'organisation.course': {
+            'Meta': {'object_name': 'Course'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        u'organisation.module': {
+            'Meta': {'object_name': 'Module'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Course']", 'null': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'})
+        }
+    }
+
+    complete_apps = ['content']
+    symmetrical = True

--- a/content/models.py
+++ b/content/models.py
@@ -68,7 +68,12 @@ class TestingQuestion(models.Model):
         ),
         default=1)
     points = models.PositiveIntegerField(
-        "Points", validators=[MaxValueValidator(500)], default=0)
+        "Points",
+        validators=[MaxValueValidator(500)],
+        default=1,
+        blank=False,
+    )
+
     textbook_link = models.CharField(
         "Textbook Link",
         max_length=500,

--- a/core/admin.py
+++ b/core/admin.py
@@ -85,7 +85,7 @@ class ParticipantPointInline(admin.TabularInline):
 
 
 class ParticipantAdmin(admin.ModelAdmin):
-    list_display = ("learner","get_firstname",
+    list_display = ("learner", "get_firstname",
         "get_lastname", "classs" '')
     list_filter = (
         LearnerFilter,

--- a/core/migrations/0012_move_from_participant_bonus_points.py
+++ b/core/migrations/0012_move_from_participant_bonus_points.py
@@ -4,13 +4,20 @@ from south.db import db
 from south.v2 import DataMigration
 from django.db import models
 
+
 class Migration(DataMigration):
 
     def forwards(self, orm):
         participants = orm.Participant.objects.all()
 
         for participant in participants:
-            participant.recalculate_total_points()
+            answers = orm.ParticipantQuestionAnswer.objects.filter(
+                participant=participant)
+            points = 0
+            for answer in answers:
+                points += answer.question.points
+            participant.points = points
+            participant.save()
 
     def backwards(self, orm):
         "Write your backwards methods here."

--- a/core/migrations/0012_move_from_participant_bonus_points.py
+++ b/core/migrations/0012_move_from_participant_bonus_points.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        participants = orm.Participant.objects.all()
+
+        for participant in participants:
+            participant.recalculate_total_points()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'auth.customuser': {
+            'Meta': {'object_name': 'CustomUser'},
+            'area': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'optin_email': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'optin_sms': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'unique_token': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            'unique_token_expiry': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.learner': {
+            'Meta': {'object_name': 'Learner', '_ormbases': [u'auth.CustomUser']},
+            u'customuser_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.CustomUser']", 'unique': 'True', 'primary_key': 'True'}),
+            'grade': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'last_active_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'last_maths_result': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'school': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.School']", 'null': 'True'}),
+            'welcome_message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['communication.Sms']", 'null': 'True', 'blank': 'True'}),
+            'welcome_message_sent': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'communication.sms': {
+            'Meta': {'object_name': 'Sms'},
+            'date_sent': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'msisdn': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'})
+        },
+        u'content.testingbank': {
+            'Meta': {'object_name': 'TestingBank'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Module']", 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'question_order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'content.testingquestion': {
+            'Meta': {'object_name': 'TestingQuestion'},
+            'answer_content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'bank': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingBank']", 'null': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'difficulty': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'points': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'question_content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'textbook_link': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'})
+        },
+        u'content.testingquestionoption': {
+            'Meta': {'object_name': 'TestingQuestionOption'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'correct': ('django.db.models.fields.BooleanField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'question': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingQuestion']", 'null': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'core.class': {
+            'Meta': {'object_name': 'Class'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Course']", 'null': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'enddate': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'startdate': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'core.participant': {
+            'Meta': {'object_name': 'Participant'},
+            'badgetemplate': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['gamification.GamificationBadgeTemplate']", 'symmetrical': 'False', 'through': u"orm['core.ParticipantBadgeTemplateRel']", 'blank': 'True'}),
+            'classs': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Class']"}),
+            'datejoined': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'learner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Learner']"}),
+            'pointbonus': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['gamification.GamificationPointBonus']", 'symmetrical': 'False', 'through': u"orm['core.ParticipantPointBonusRel']", 'blank': 'True'}),
+            'points': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        u'core.participantbadgetemplaterel': {
+            'Meta': {'object_name': 'ParticipantBadgeTemplateRel'},
+            'awarddate': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 8, 21, 0, 0)', 'null': 'True'}),
+            'badgetemplate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationBadgeTemplate']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Participant']"}),
+            'scenario': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationScenario']"})
+        },
+        u'core.participantpointbonusrel': {
+            'Meta': {'object_name': 'ParticipantPointBonusRel'},
+            'awarddate': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 8, 21, 0, 0)', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Participant']"}),
+            'pointbonus': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationPointBonus']"}),
+            'scenario': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationScenario']"})
+        },
+        u'core.participantquestionanswer': {
+            'Meta': {'object_name': 'ParticipantQuestionAnswer'},
+            'answerdate': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2014, 8, 21, 0, 0)', 'null': 'True'}),
+            'correct': ('django.db.models.fields.BooleanField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'option_selected': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingQuestionOption']"}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Participant']"}),
+            'question': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingQuestion']"})
+        },
+        u'gamification.gamificationbadgetemplate': {
+            'Meta': {'object_name': 'GamificationBadgeTemplate'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'gamification.gamificationpointbonus': {
+            'Meta': {'object_name': 'GamificationPointBonus'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'value': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'})
+        },
+        u'gamification.gamificationscenario': {
+            'Meta': {'object_name': 'GamificationScenario'},
+            'badge': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationBadgeTemplate']", 'null': 'True', 'blank': 'True'}),
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Course']", 'null': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'event': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Module']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationPointBonus']", 'null': 'True', 'blank': 'True'})
+        },
+        u'organisation.course': {
+            'Meta': {'object_name': 'Course'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        u'organisation.module': {
+            'Meta': {'object_name': 'Module'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Course']", 'null': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'})
+        },
+        u'organisation.organisation': {
+            'Meta': {'object_name': 'Organisation'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        u'organisation.school': {
+            'Meta': {'object_name': 'School'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Organisation']", 'null': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['core']
+    symmetrical = True

--- a/core/migrations/0012_move_from_participant_bonus_points.py
+++ b/core/migrations/0012_move_from_participant_bonus_points.py
@@ -12,7 +12,8 @@ class Migration(DataMigration):
 
         for participant in participants:
             answers = orm.ParticipantQuestionAnswer.objects.filter(
-                participant=participant)
+                participant=participant,
+                correct=True)
             points = 0
             for answer in answers:
                 points += answer.question.points

--- a/core/models.py
+++ b/core/models.py
@@ -92,7 +92,9 @@ class Participant(models.Model):
 
     # Probably to be used in migrations
     def recalculate_total_points(self):
-        answers = ParticipantQuestionAnswer.objects.filter(participant=self)
+        answers = ParticipantQuestionAnswer.objects.filter(
+            participant=self,
+            correct=True)
         points = 0
         for answer in answers:
             points += answer.question.points

--- a/core/models.py
+++ b/core/models.py
@@ -86,8 +86,9 @@ class Participant(models.Model):
         )
         answer.save()
 
-        # Award points
-        self.award_points(question.points)
+        # Award points to participant
+        self.points += question.points
+        self.save()
 
     # Probably to be used in migrations
     def recalculate_total_points(self):
@@ -98,11 +99,6 @@ class Participant(models.Model):
         self.points = points
         self.save()
         return points
-
-    # Update the total points
-    def award_points(self, points):
-        self.points += points
-        self.save()
 
     # Scenario's only apply to badges
     def award_scenario(self, event, module):

--- a/core/tests.py
+++ b/core/tests.py
@@ -27,9 +27,9 @@ class TestMessage(TestCase):
     def create_test_question(self, name, bank, **kwargs):
         return TestingQuestion.objects.create(name=name, bank=bank, **kwargs)
 
-    def create_test_question_option(self, name, question):
+    def create_test_question_option(self, name, question, correct=True):
         return TestingQuestionOption.objects.create(
-            name=name, question=question, correct=True)
+            name=name, question=question, correct=correct)
 
     def create_testbank(self, name, module, **kwargs):
         return TestingBank.objects.create(name=name, module=module, **kwargs)
@@ -153,6 +153,22 @@ class TestMessage(TestCase):
 
         scenarios = self.participant.get_scenarios(event, self.module)
         self.assertEqual(scenarios.first(), self.scenario)
+
+    def test_recalculate_points_only_right(self):
+        question2 = self.create_test_question(name="testquestion2",
+                                              bank=self.testbank)
+
+        option2 = self.create_test_question_option(name="option2",
+                                                   question=question2,
+                                                   correct=False)
+        self.participant.answer(self.question, self.option)
+        self.participant.answer(question2, option2)
+
+        self.participant.points = 0
+
+        self.participant.recalculate_total_points()
+        self.assertEqual(self.participant.points, 1)
+
 
 
 


### PR DESCRIPTION
- Removed points from award scenario
- Created an answer method for participant which updates points and creates the answer object
- Default question points to 1
- Added a data migration to set all question points to 1
- Add a data migration to recalculate a user's points based on the answer objects, rather than point object
- Added tests for the new & refactored methods
- Did not remove PointsBonus yet, so that if learners complain after the migration, we have some sort of frame of reference. 
