### PR TITLE
DIG-54 Allow notifying learners of new questions

### DIFF
--- a/content/models.py
+++ b/content/models.py
@@ -4,10 +4,9 @@ from organisation.models import Module
 from django.core.urlresolvers import reverse
 from django.utils.html import remove_tags, format_html
 from mobileu.utils import format_content, format_option
-from django.db.models import Count
+from django.db.models import Count, get_model
 from datetime import datetime
 from organisation.models import CourseModuleRel
-from core.models import Class, Participant, ParticipantQuestionAnswer
 from django.core.mail import mail_managers
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -103,6 +102,9 @@ class TestingQuestion(models.Model):
     def get_unanswered_participants(self):
         if not self.module.is_active:
             return None
+        Class = get_model("core", "Class")
+        Participant = get_model("core", "Participant")
+        ParticipantQuestionAnswer = get_model("core", "ParticipantQuestionAnswer")
         course_rels = CourseModuleRel.objects.filter(module__is_active=True,
                                                      module_id=self.module_id)
         classes = Class.objects.filter(is_active=True,

--- a/content/models.py
+++ b/content/models.py
@@ -114,7 +114,9 @@ class TestingQuestion(models.Model):
         answered = ParticipantQuestionAnswer.objects.filter(
             question_id=self.id,
             participant__in=participants)
-        return participants.exclude(answered)
+        if answered is None:
+            participants = participants.exclude(answered)
+        return participants
 
     class Meta:
         verbose_name = "Test Question"

--- a/content/models.py
+++ b/content/models.py
@@ -100,7 +100,7 @@ class TestingQuestion(models.Model):
         super(TestingQuestion, self).save(*args, **kwargs)
 
     def get_unanswered_participants(self):
-        if not self.module.is_active:
+        if not self.module.is_active or self.state != self.PUBLISHED:
             return None
         Class = get_model("core", "Class")
         Participant = get_model("core", "Participant")
@@ -114,8 +114,8 @@ class TestingQuestion(models.Model):
         answered = ParticipantQuestionAnswer.objects.filter(
             question_id=self.id,
             participant__in=participants)
-        if answered is None:
-            participants = participants.exclude(answered)
+        if answered is not None:
+            participants = participants.exclude(participantquestionanswer__in=answered)
         return participants
 
     class Meta:

--- a/content/models.py
+++ b/content/models.py
@@ -7,6 +7,7 @@ from mobileu.utils import format_content, format_option
 from django.db.models import Count
 from datetime import datetime
 from organisation.models import CourseModuleRel
+from core.models import Class, Participant, ParticipantQuestionAnswer
 from django.core.mail import mail_managers
 from django.utils.encoding import python_2_unicode_compatible
 
@@ -98,6 +99,20 @@ class TestingQuestion(models.Model):
         self.question_content = format_content(self.question_content)
         self.answer_content = format_content(self.answer_content)
         super(TestingQuestion, self).save(*args, **kwargs)
+
+    def get_unanswered_participants(self):
+        if not self.module.is_active:
+            return None
+        course_rels = CourseModuleRel.objects.filter(module__is_active=True,
+                                                     module_id=self.module_id)
+        classes = Class.objects.filter(is_active=True,
+                                       course_id__in=[course.course_id for course in course_rels])
+        participants = Participant.objects.filter(is_active=True,
+                                                  classs__in=classes)
+        answered = ParticipantQuestionAnswer.objects.filter(
+            question_id=self.id,
+            participant__in=participants)
+        return participants.exclude(answered)
 
     class Meta:
         verbose_name = "Test Question"

--- a/content/tasks.py
+++ b/content/tasks.py
@@ -74,12 +74,12 @@ def sms_new_questions_body(questions, msg=None):
         participants |= question.get_unanswered_participants()
 
     learners = Learner.objects.filter(participant__in=participants)
+    if learners is None:
+        return
 
     if msg is None:
-        try:
-            msg = Setting.get_setting('LEARNER_NEW_QUESTIONS_MSG')
-        except:
-            msg = 'Hi, there. We have new questions for you on Dig-it!'
+        msg = Setting.get_setting('LEARNER_NEW_QUESTIONS_MSG',
+                                  default='Hi, there. We have new questions for you on Dig-it!')
 
     vumi = VumiSmsApi()
     vumi.send_all(learners, msg)

--- a/content/tasks.py
+++ b/content/tasks.py
@@ -76,7 +76,7 @@ def sms_new_questions_body(questions, msg=None):
             participants = participants | new_participants
 
     learners = Learner.objects.filter(participant__in=participants)
-    if learners is None:
+    if learners is None or len(learners) == 0:
         return
 
     if msg is None:

--- a/content/tasks.py
+++ b/content/tasks.py
@@ -71,7 +71,9 @@ def sms_new_questions_body(questions, msg=None):
     participants = Participant.objects.none()
 
     for question in questions:
-        participants |= question.get_unanswered_participants()
+        new_participants = question.get_unanswered_participants()
+        if new_participants is not None:
+            participants = participants | new_participants
 
     learners = Learner.objects.filter(participant__in=participants)
     if learners is None:
@@ -82,4 +84,4 @@ def sms_new_questions_body(questions, msg=None):
                                   default='Hi, there. We have new questions for you on Dig-it!')
 
     vumi = VumiSmsApi()
-    vumi.send_all(learners, msg)
+    vumi.send_all(learners, message=msg)

--- a/content/tests.py
+++ b/content/tests.py
@@ -5,12 +5,12 @@ from content.forms import process_mathml_content, render_mathml, convert_to_tags
 from organisation.models import Course, Module, CourseModuleRel, School, Organisation
 from auth.models import Learner
 from core.models import Participant, Class, ParticipantBadgeTemplateRel, ParticipantQuestionAnswer
-from content.tasks import end_event_processing_body
+from content.tasks import end_event_processing_body, sms_new_questions_body
 from mobileu.tasks import send_sumit_counts_body
 
 from django.test import TestCase
 from datetime import datetime, timedelta
-from mock import patch
+from mock import ANY, patch
 from django.conf import settings
 import os
 
@@ -617,3 +617,121 @@ class TestContent(TestCase):
         participant.classs = new_class
         participant.save()
         self.assertEqual(self.question.get_unanswered_participants().count(), num_learners - num_answered - 1)
+
+    @patch('content.tasks.VumiSmsApi', autospec=True)
+    def test_sms_new_questions_body(self, fake_vumi):
+        num_learners = 15
+        self.learner.delete()
+        self.participant.delete()
+        self.question.state = self.question.PUBLISHED
+        self.question.save()
+
+        # no one has answered the question yet, single question
+        for i in range(num_learners):
+            learner = Learner.objects.create(username='learn%d' % (i,),
+                                             first_name='Learn%d' % (i,),
+                                             mobile='012345%04d' % (i,),
+                                             school=self.school,
+                                             grade="Grade 12")
+            participant = Participant.objects.create(learner=learner,
+                                                     classs=self.classs,
+                                                     datejoined=datetime.now())
+        sms_new_questions_body(TestingQuestion.objects.filter(pk=self.question.id))
+        fake_vumi().send_all.assert_called_once_with(ANY, message='Hi, there. We have new questions for you on Dig-it!')
+        args, kwargs = fake_vumi().send_all.call_args
+        self.assertEqual(len(args), 1)
+        self.assertEqual(len(args[0]), num_learners)
+
+        # no one has answered the question yet, multiple questions
+        fake_vumi.reset_mock()
+        self.question.delete()
+        num_questions = 5
+        for i in range(num_questions):
+            TestingQuestion.objects.create(name='Q%d' % (i,),
+                                           module=self.module,
+                                           state=TestingQuestion.PUBLISHED)
+        questions = TestingQuestion.objects.all()
+        sms_new_questions_body(questions)
+        fake_vumi().send_all.assert_called_once_with(ANY, message='Hi, there. We have new questions for you on Dig-it!')
+        args, kwargs = fake_vumi().send_all.call_args
+        self.assertEqual(len(args), 1)
+        self.assertEqual(len(args[0]), num_learners)
+
+        # some questions answered
+        fake_vumi.reset_mock()
+        participant = Participant.objects.all().last()
+        for i in range(questions.count()):
+            question = questions[i]
+            option = TestingQuestionOption.objects.create(name='A%d' % (i,),
+                                                          question=question,
+                                                          correct=True)
+            ParticipantQuestionAnswer.objects.create(question=question,
+                                                     participant=participant,
+                                                     option_selected=option,
+                                                     correct=option.correct)
+        sms_new_questions_body(questions)
+        fake_vumi().send_all.assert_called_once_with(ANY, message='Hi, there. We have new questions for you on Dig-it!')
+        args, kwargs = fake_vumi().send_all.call_args
+        self.assertEqual(len(args), 1)
+        self.assertEqual(len(args[0]), num_learners - 1)
+
+        # some questions in different module
+        fake_vumi.reset_mock()
+        ParticipantQuestionAnswer.objects.all().delete()
+        num_questions_moved = 2
+        new_course = self.create_course(name='Best course')
+        new_module = self.create_module('Best module', new_course)
+        for question in questions[:num_questions_moved]:
+            question.module = new_module
+            question.save()
+        sms_new_questions_body(questions)
+        fake_vumi().send_all.assert_called_once_with(ANY, message='Hi, there. We have new questions for you on Dig-it!')
+        args, kwargs = fake_vumi().send_all.call_args
+        self.assertEqual(len(args), 1)
+        self.assertEqual(len(args[0]), num_learners)
+
+        # some learners in different class, with different modules
+        fake_vumi.reset_mock()
+        num_participants_moved = 5
+        new_class = self.create_class('Best class', new_course)
+        participants = Participant.objects.all()
+        for participant in participants[:num_participants_moved]:
+            participant.classs = new_class
+            participant.save()
+        sms_new_questions_body(questions)
+        fake_vumi().send_all.assert_called_once_with(ANY, message='Hi, there. We have new questions for you on Dig-it!')
+        args, kwargs = fake_vumi().send_all.call_args
+        self.assertEqual(len(args), 1)
+        self.assertEqual(len(args[0]), num_learners)
+
+        # different classes, different modules, some answered
+        fake_vumi.reset_mock()
+        participant_skip_count = 2
+        num_participants_answered = 0
+        for participant in participants[::participant_skip_count]:
+            for question in questions:
+                option = TestingQuestionOption.objects.get(question=question)
+                ParticipantQuestionAnswer.objects.create(question=question,
+                                                         participant=participant,
+                                                         option_selected=option,
+                                                         correct=option.correct)
+            num_participants_answered += 1
+        sms_new_questions_body(questions)
+        fake_vumi().send_all.assert_called_once_with(ANY, message='Hi, there. We have new questions for you on Dig-it!')
+        args, kwargs = fake_vumi().send_all.call_args
+        self.assertEqual(len(args), 1)
+        self.assertEqual(len(args[0]), num_learners - num_participants_answered)
+
+        # different classes, different modules, all answered
+        fake_vumi.reset_mock()
+        ParticipantQuestionAnswer.objects.all().delete()
+        num_participants_answered = num_learners
+        for participant in participants:
+            for question in questions:
+                option = TestingQuestionOption.objects.get(question=question)
+                ParticipantQuestionAnswer.objects.create(question=question,
+                                                         participant=participant,
+                                                         option_selected=option,
+                                                         correct=option.correct)
+        sms_new_questions_body(questions)
+        self.assertFalse(fake_vumi.called)

--- a/core/models.py
+++ b/core/models.py
@@ -328,13 +328,12 @@ class Setting(models.Model):
     value = models.TextField("Value", max_length=100, blank=False)
 
     @staticmethod
-    def get_setting(key):
-        setting = Setting.objects.filter(key__exact=key).first()
-
-        if setting:
+    def get_setting(key, default=None):
+        try:
+            setting = Setting.objects.get(key=key)
             return setting.value
-        else:
-            return None
+        except:
+            return default
 
 
 class TaskLogger(models.Model):


### PR DESCRIPTION
- [X] Add `get_unanswered_participants()` method to `TestingQuestion`.
- [X] Add task for sending SMS notification of new questions to learners.
- [x] Write tests for `get_unanswered_participants()`.
- [x] Write tests for SMS notification task.
- [ ] Add support for new question notification to `TestingQuestion` admin panel.

_Additional_
- [X] Extend `Setting.get_setting` static method with support for default values. (If `default` is specified and key doesn't exist, returns `default`.)
