### PR TITLE
Rename Haystack fields entry to new name.

### DIFF
--- a/mobileu/haystack_custom.py
+++ b/mobileu/haystack_custom.py
@@ -64,7 +64,7 @@ class FuzzyBackend(ElasticsearchSearchBackend):
             if isinstance(fields, (list, set)):
                 fields = " ".join(fields)
 
-            kwargs['fields'] = fields
+            kwargs['stored_fields'] = fields
 
         if sort_by is not None:
             order_list = []


### PR DESCRIPTION
- [x] Fix ElasticSearch complaining about deprecated `fields` kwarg.