### PR TITLE
Add migration for making URLs in DB relative.

### DIFF
--- a/content/migrations/0035_relative_urls.py
+++ b/content/migrations/0035_relative_urls.py
@@ -1,0 +1,381 @@
+# -*- coding: utf-8 -*-
+from south.utils import datetime_utils as datetime
+from south.db import db
+from south.v2 import DataMigration
+from django.db import models
+from django.db.models import Q
+import re
+
+
+class Migration(DataMigration):
+
+    def forwards(self, orm):
+        "Write your forwards methods here."
+        # Note: Don't use "from appname.models import ModelName". 
+        # Use orm.ModelName to refer to models in this application,
+        # and orm['appname.ModelName'] for models in other applications.
+        regex = re.compile("http://.*/media/")
+        for item in orm.TestingQuestion.objects.filter(
+                Q(question_content__contains='/media/') | Q(answer_content__contains='/media/')):
+            item.question_content = regex.sub("/media/", item.question_content)
+            item.answer_content = regex.sub("/media/", item.answer_content)
+            item.save()
+
+    def backwards(self, orm):
+        "Write your backwards methods here."
+
+    models = {
+        u'auth.customuser': {
+            'Meta': {'object_name': 'CustomUser'},
+            'area': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'city': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'country': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'date_joined': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            'first_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'groups': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Group']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'is_staff': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'is_superuser': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'last_login': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime.now'}),
+            'last_name': ('django.db.models.fields.CharField', [], {'max_length': '30', 'blank': 'True'}),
+            'mobile': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'optin_email': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'optin_sms': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'pass_reset_token': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            'pass_reset_token_expiry': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'password': ('django.db.models.fields.CharField', [], {'max_length': '128'}),
+            'unique_token': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            'unique_token_expiry': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'user_permissions': ('django.db.models.fields.related.ManyToManyField', [], {'symmetrical': 'False', 'related_name': "u'user_set'", 'blank': 'True', 'to': u"orm['auth.Permission']"}),
+            'username': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '30'})
+        },
+        u'auth.group': {
+            'Meta': {'object_name': 'Group'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '80'}),
+            'permissions': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['auth.Permission']", 'symmetrical': 'False', 'blank': 'True'})
+        },
+        u'auth.learner': {
+            'Meta': {'object_name': 'Learner', '_ormbases': [u'auth.CustomUser']},
+            u'customuser_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['auth.CustomUser']", 'unique': 'True', 'primary_key': 'True'}),
+            'enrolled': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1', 'blank': 'True'}),
+            'grade': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'last_active_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'last_maths_result': ('django.db.models.fields.FloatField', [], {'null': 'True', 'blank': 'True'}),
+            'public_share': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'school': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.School']", 'null': 'True'}),
+            'terms_accept': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'welcome_message': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['communication.Sms']", 'null': 'True', 'blank': 'True'}),
+            'welcome_message_sent': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'auth.permission': {
+            'Meta': {'ordering': "(u'content_type__app_label', u'content_type__model', u'codename')", 'unique_together': "((u'content_type', u'codename'),)", 'object_name': 'Permission'},
+            'codename': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'content_type': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['contenttypes.ContentType']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'})
+        },
+        u'communication.sms': {
+            'Meta': {'object_name': 'Sms'},
+            'date_sent': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'msisdn': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'blank': 'True'}),
+            'respond_date': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'responded': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'response': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['communication.SmsQueue']", 'null': 'True', 'blank': 'True'}),
+            'uuid': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True'})
+        },
+        u'communication.smsqueue': {
+            'Meta': {'object_name': 'SmsQueue'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'message': ('django.db.models.fields.TextField', [], {}),
+            'msisdn': ('django.db.models.fields.CharField', [], {'max_length': '50', 'null': 'True', 'db_index': 'True'}),
+            'send_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'sent': ('django.db.models.fields.BooleanField', [], {'default': 'False', 'db_index': 'True'}),
+            'sent_date': ('django.db.models.fields.DateTimeField', [], {'default': 'None', 'null': 'True', 'blank': 'True'})
+        },
+        u'content.definition': {
+            'Meta': {'object_name': 'Definition'},
+            'definition': ('django.db.models.fields.TextField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '255'})
+        },
+        u'content.event': {
+            'Meta': {'object_name': 'Event'},
+            'activation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'airtime': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Course']"}),
+            'deactivation_date': ('django.db.models.fields.DateTimeField', [], {}),
+            'end_processed': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'event_badge': ('django.db.models.fields.related.ForeignKey', [], {'blank': 'True', 'related_name': "'event_badge'", 'null': 'True', 'to': u"orm['gamification.GamificationScenario']"}),
+            'event_points': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '50'}),
+            'number_sittings': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'type': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        u'content.eventendpage': {
+            'Meta': {'object_name': 'EventEndPage'},
+            'event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.Event']", 'null': 'True'}),
+            'header': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'paragraph': ('django.db.models.fields.TextField', [], {'max_length': '500'})
+        },
+        u'content.eventparticipantrel': {
+            'Meta': {'object_name': 'EventParticipantRel'},
+            'event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.Event']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Participant']", 'null': 'True'}),
+            'results_received': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'sitting_number': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'sumit_level': ('django.db.models.fields.CharField', [], {'max_length': '50', 'blank': 'True'}),
+            'winner': ('django.db.models.fields.BooleanField', [], {'default': 'False'})
+        },
+        u'content.eventquestionanswer': {
+            'Meta': {'object_name': 'EventQuestionAnswer'},
+            'answer_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'null': 'True', 'blank': 'True'}),
+            'correct': ('django.db.models.fields.BooleanField', [], {}),
+            'event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.Event']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Participant']", 'null': 'True'}),
+            'question': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingQuestion']", 'null': 'True'}),
+            'question_option': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingQuestionOption']", 'null': 'True'})
+        },
+        u'content.eventquestionrel': {
+            'Meta': {'object_name': 'EventQuestionRel'},
+            'event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.Event']", 'null': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'question': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingQuestion']", 'null': 'True'})
+        },
+        u'content.eventsplashpage': {
+            'Meta': {'object_name': 'EventSplashPage'},
+            'event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.Event']", 'null': 'True'}),
+            'header': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'order_number': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'}),
+            'paragraph': ('django.db.models.fields.TextField', [], {'max_length': '500'})
+        },
+        u'content.eventstartpage': {
+            'Meta': {'object_name': 'EventStartPage'},
+            'event': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.Event']", 'null': 'True'}),
+            'header': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'paragraph': ('django.db.models.fields.TextField', [], {'max_length': '500'})
+        },
+        u'content.goldenegg': {
+            'Meta': {'object_name': 'GoldenEgg'},
+            'active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'airtime': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'badge': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationScenario']", 'null': 'True', 'blank': 'True'}),
+            'classs': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Class']", 'null': 'True', 'blank': 'True'}),
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Course']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'point_value': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'content.goldeneggrewardlog': {
+            'Meta': {'object_name': 'GoldenEggRewardLog'},
+            'airtime': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'award_date': ('django.db.models.fields.DateTimeField', [], {'auto_now_add': 'True', 'blank': 'True'}),
+            'badge': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationScenario']", 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Participant']"}),
+            'points': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'content.learningchapter': {
+            'Meta': {'object_name': 'LearningChapter'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Module']", 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'content.mathml': {
+            'Meta': {'object_name': 'Mathml'},
+            'error': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'filename': ('django.db.models.fields.CharField', [], {'max_length': '255', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'mathml_content': ('django.db.models.fields.TextField', [], {}),
+            'rendered': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'source': ('django.db.models.fields.IntegerField', [], {'max_length': '1'}),
+            'source_id': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'content.sumit': {
+            'Meta': {'object_name': 'SUMit', '_ormbases': [u'content.Event']},
+            u'event_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['content.Event']", 'unique': 'True', 'primary_key': 'True'})
+        },
+        u'content.sumitendpage': {
+            'Meta': {'object_name': 'SUMitEndPage', '_ormbases': [u'content.EventEndPage']},
+            u'eventendpage_ptr': ('django.db.models.fields.related.OneToOneField', [], {'to': u"orm['content.EventEndPage']", 'unique': 'True', 'primary_key': 'True'}),
+            'type': ('django.db.models.fields.PositiveIntegerField', [], {})
+        },
+        u'content.sumitlevel': {
+            'Meta': {'object_name': 'SUMitLevel'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '50'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'question_1': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'question_2': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'question_3': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        u'content.testingquestion': {
+            'Meta': {'ordering': "['name']", 'object_name': 'TestingQuestion'},
+            'answer_content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'difficulty': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Module']", 'null': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "'Auto Generated'", 'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'notes': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'points': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'question_content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'state': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'textbook_link': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'})
+        },
+        u'content.testingquestiondifficulty': {
+            'Meta': {'object_name': 'TestingQuestionDifficulty'},
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'key': ('django.db.models.fields.PositiveIntegerField', [], {'unique': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'unique': 'True', 'max_length': '20'}),
+            'value': ('django.db.models.fields.IntegerField', [], {})
+        },
+        u'content.testingquestionoption': {
+            'Meta': {'object_name': 'TestingQuestionOption'},
+            'content': ('django.db.models.fields.TextField', [], {'blank': 'True'}),
+            'correct': ('django.db.models.fields.BooleanField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'default': "'Auto Generated'", 'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'}),
+            'question': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['content.TestingQuestion']", 'null': 'True'})
+        },
+        u'contenttypes.contenttype': {
+            'Meta': {'ordering': "('name',)", 'unique_together': "(('app_label', 'model'),)", 'object_name': 'ContentType', 'db_table': "'django_content_type'"},
+            'app_label': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'model': ('django.db.models.fields.CharField', [], {'max_length': '100'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '100'})
+        },
+        u'core.class': {
+            'Meta': {'object_name': 'Class'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Course']", 'null': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'enddate': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'province': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'startdate': ('django.db.models.fields.DateTimeField', [], {'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'core.participant': {
+            'Meta': {'object_name': 'Participant'},
+            'badgetemplate': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['gamification.GamificationBadgeTemplate']", 'symmetrical': 'False', 'through': u"orm['core.ParticipantBadgeTemplateRel']", 'blank': 'True'}),
+            'classs': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Class']"}),
+            'datejoined': ('django.db.models.fields.DateTimeField', [], {}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'learner': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['auth.Learner']"}),
+            'pointbonus': ('django.db.models.fields.related.ManyToManyField', [], {'to': u"orm['gamification.GamificationPointBonus']", 'symmetrical': 'False', 'through': u"orm['core.ParticipantPointBonusRel']", 'blank': 'True'}),
+            'points': ('django.db.models.fields.PositiveIntegerField', [], {'default': '0'})
+        },
+        u'core.participantbadgetemplaterel': {
+            'Meta': {'object_name': 'ParticipantBadgeTemplateRel'},
+            'awardcount': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'awarddate': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2017, 8, 8, 0, 0)', 'null': 'True'}),
+            'badgetemplate': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationBadgeTemplate']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Participant']"}),
+            'scenario': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationScenario']"})
+        },
+        u'core.participantpointbonusrel': {
+            'Meta': {'object_name': 'ParticipantPointBonusRel'},
+            'awarddate': ('django.db.models.fields.DateTimeField', [], {'default': 'datetime.datetime(2017, 8, 8, 0, 0)', 'null': 'True', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'participant': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['core.Participant']"}),
+            'pointbonus': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationPointBonus']"}),
+            'scenario': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationScenario']"})
+        },
+        u'gamification.gamificationbadgetemplate': {
+            'Meta': {'object_name': 'GamificationBadgeTemplate'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'False'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'})
+        },
+        u'gamification.gamificationpointbonus': {
+            'Meta': {'object_name': 'GamificationPointBonus'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'image': ('django.db.models.fields.files.ImageField', [], {'max_length': '100', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'value': ('django.db.models.fields.PositiveIntegerField', [], {'null': 'True'})
+        },
+        u'gamification.gamificationscenario': {
+            'Meta': {'object_name': 'GamificationScenario'},
+            'award_type': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'badge': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationBadgeTemplate']", 'null': 'True', 'blank': 'True'}),
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Course']", 'null': 'True', 'blank': 'True'}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'event': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Module']", 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'point': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['gamification.GamificationPointBonus']", 'null': 'True', 'blank': 'True'})
+        },
+        u'organisation.course': {
+            'Meta': {'object_name': 'Course'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'question_order': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'slug': ('django.db.models.fields.SlugField', [], {'max_length': '50', 'blank': 'True'})
+        },
+        u'organisation.coursemodulerel': {
+            'Meta': {'object_name': 'CourseModuleRel'},
+            'course': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Course']"}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'module': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Module']"})
+        },
+        u'organisation.module': {
+            'Meta': {'object_name': 'Module'},
+            'courses': ('django.db.models.fields.related.ManyToManyField', [], {'related_name': "'modules'", 'symmetrical': 'False', 'through': u"orm['organisation.CourseModuleRel']", 'to': u"orm['organisation.Course']"}),
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'is_active': ('django.db.models.fields.BooleanField', [], {'default': 'True'}),
+            'module_link': ('django.db.models.fields.CharField', [], {'max_length': '500', 'null': 'True', 'blank': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'order': ('django.db.models.fields.IntegerField', [], {'null': 'True', 'blank': 'True'}),
+            'type': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'})
+        },
+        u'organisation.organisation': {
+            'Meta': {'object_name': 'Organisation'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        },
+        u'organisation.school': {
+            'Meta': {'object_name': 'School'},
+            'description': ('django.db.models.fields.CharField', [], {'max_length': '500', 'blank': 'True'}),
+            'email': ('django.db.models.fields.EmailField', [], {'max_length': '75', 'blank': 'True'}),
+            u'id': ('django.db.models.fields.AutoField', [], {'primary_key': 'True'}),
+            'name': ('django.db.models.fields.CharField', [], {'max_length': '500', 'unique': 'True', 'null': 'True'}),
+            'open_type': ('django.db.models.fields.PositiveIntegerField', [], {'default': '1'}),
+            'organisation': ('django.db.models.fields.related.ForeignKey', [], {'to': u"orm['organisation.Organisation']", 'null': 'True'}),
+            'province': ('django.db.models.fields.CharField', [], {'max_length': '20', 'null': 'True', 'blank': 'True'}),
+            'website': ('django.db.models.fields.URLField', [], {'max_length': '200', 'blank': 'True'})
+        }
+    }
+
+    complete_apps = ['content']
+    symmetrical = True


### PR DESCRIPTION
In question/answer content for `TestingQuestion`, replace replace as recommended by Milton:
>A naive approach would be to do this in a management command
```t.question_content = t.question_content.replace('http://www.dig-it.me/media/', '/media/')```
>
>But a better approach would be to use regex to match the absolute URL `http://*/media/` and replace it with `/media/` without specifying the domain so that the same script can be used in QA and Prod 